### PR TITLE
Setmap command

### DIFF
--- a/Content.Server/_CorvaxNext/GameTicking/Commands/SetMapCommand.cs
+++ b/Content.Server/_CorvaxNext/GameTicking/Commands/SetMapCommand.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.GameTicking;
+using Content.Server.Maps;
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Stories.GameTicking.Commands
+{
+    [AdminCommand(AdminFlags.Round)]
+    sealed class SetMapCommand : IConsoleCommand
+    {
+        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IGameMapManager _gameMapManager = default!;
+
+        public string Command => "setmap";
+        public string Description => Loc.GetString("setmap-command-description");
+        public string Help => Loc.GetString("setmap-command-help");
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (args.Length != 1)
+            {
+                shell.WriteLine(Loc.GetString("setmap-command-need-one-argument"));
+                return;
+            }
+
+            var name = args[0];
+
+            var ticker = _entityManager.EntitySysManager.GetEntitySystem<GameTicker>();
+            if (ticker.CanUpdateMap())
+            {
+                // deny effect of forcemap if it was used before
+                _configurationManager.SetCVar(CCVars.GameMap, "");
+
+                _gameMapManager.SelectMap(name);
+                ticker.UpdateInfoText();
+                shell.WriteLine(Loc.GetString("setmap-command-success", ("map", name)));
+            }
+            else
+            {
+                ticker.Log.Debug("Ticker cannot update map");
+                shell.WriteLine(Loc.GetString("setmap-command-failed", ("map", name)));
+            }
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 1)
+            {
+                var options = IoCManager.Resolve<IPrototypeManager>()
+                    .EnumeratePrototypes<GameMapPrototype>()
+                    .Select(p => new CompletionOption(p.ID, p.MapName))
+                    .OrderBy(p => p.Value);
+
+                return CompletionResult.FromHintOptions(options, Loc.GetString("setmap-command-arg-map"));
+            }
+
+            return CompletionResult.Empty;
+        }
+    }
+}

--- a/Resources/Locale/en-US/commands/setmap-command.ftl
+++ b/Resources/Locale/en-US/commands/setmap-command.ftl
@@ -1,0 +1,7 @@
+## setmap command loc.
+
+setmap-command-description = Forces the game to start with a given map next round.
+setmap-command-help = setmap <map ID>
+setmap-command-need-one-argument = setmap takes one argument, the path to the map file.
+setmap-command-success = Forced the game to start with map { $map } next round.
+setmap-command-arg-map = <map ID>

--- a/Resources/Locale/ru-RU/commands/setmap-command.ftl
+++ b/Resources/Locale/ru-RU/commands/setmap-command.ftl
@@ -1,0 +1,5 @@
+setmap-command-description = Заставляет игру начать с заданной карты в следующем раунде.
+setmap-command-help = setmap <map ID>
+setmap-command-need-one-argument = setmap принимает один аргумент — путь к файлу карты.
+setmap-command-success = В следующем раунде игра принудительно начнется с карты { $map }.
+setmap-command-arg-map = <map ID>


### PR DESCRIPTION
## Описание PR
Добавление команды setmap, позволяющей ставить карту в лобби без использования команды forcemap. Это может быть полезно в случаях, когда нужно установить карту на один раунд.

**Список изменений**
Добавлена новая команда - setmap
