### PR TITLE
Вырезал граб помощнику варда

### DIFF
--- a/Resources/Prototypes/_CorvaxNext/Roles/Jobs/Security/wardenHelper.yml
+++ b/Resources/Prototypes/_CorvaxNext/Roles/Jobs/Security/wardenHelper.yml
@@ -26,7 +26,6 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
     components:
-      - type: CanChokeGrab # Corvax-Next-Grab
       - type: Skills # Corvax-Next-Skills
         skills:
         - Shooting


### PR DESCRIPTION

## Описание PR
Убрал граб у помощника вардена

## Почему / Баланс
У помощника вардена есть граб, баланс ломает.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the Warden Helper job configuration by removing a specific ability. No other changes were made to job skills or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->