### PR TITLE
RND server grid-local

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.Client.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Client.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Research.Components;
 
@@ -12,6 +13,7 @@ public sealed partial class ResearchSystem
         SubscribeLocalEvent<ResearchClientComponent, ComponentShutdown>(OnClientShutdown);
         SubscribeLocalEvent<ResearchClientComponent, BoundUIOpenedEvent>(OnClientUIOpen);
         SubscribeLocalEvent<ResearchClientComponent, ConsoleServerSelectionMessage>(OnConsoleSelect);
+        SubscribeLocalEvent<ResearchClientComponent, AnchorStateChangedEvent>(OnClientAnchorStateChanged);
 
         SubscribeLocalEvent<ResearchClientComponent, ResearchClientSyncMessage>(OnClientSyncMessage);
         SubscribeLocalEvent<ResearchClientComponent, ResearchClientServerSelectedMessage>(OnClientSelected);
@@ -23,7 +25,11 @@ public sealed partial class ResearchSystem
 
     private void OnClientSelected(EntityUid uid, ResearchClientComponent component, ResearchClientServerSelectedMessage args)
     {
-        if (!TryGetServerById(args.ServerId, out var serveruid, out var serverComponent))
+        if (!TryGetServerById(uid, args.ServerId, out var serveruid, out var serverComponent))
+            return;
+
+        // Validate that we can access this server.
+        if (!GetServers(uid).Contains((serveruid.Value, serverComponent)))
             return;
 
         UnregisterClient(uid, component);
@@ -56,12 +62,7 @@ public sealed partial class ResearchSystem
 
     private void OnClientMapInit(EntityUid uid, ResearchClientComponent component, MapInitEvent args)
     {
-        var allServers = new List<Entity<ResearchServerComponent>>();
-        var query = AllEntityQuery<ResearchServerComponent>();
-        while (query.MoveNext(out var serverUid, out var serverComp))
-        {
-            allServers.Add((serverUid, serverComp));
-        }
+        var allServers = GetServers(uid).ToList();
 
         if (allServers.Count > 0)
             RegisterClient(uid, allServers[0], component, allServers[0]);
@@ -77,6 +78,24 @@ public sealed partial class ResearchSystem
         UpdateClientInterface(uid, component);
     }
 
+    private void OnClientAnchorStateChanged(Entity<ResearchClientComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        if (args.Anchored)
+        {
+            if (ent.Comp.Server is not null)
+                return;
+
+            var allServers = GetServers(ent).ToList();
+
+            if (allServers.Count > 0)
+                RegisterClient(ent, allServers[0], ent, allServers[0]);
+        }
+        else
+        {
+            UnregisterClient(ent, ent.Comp);
+        }
+    }
+
     private void UpdateClientInterface(EntityUid uid, ResearchClientComponent? component = null)
     {
         if (!Resolve(uid, ref component, false))
@@ -84,9 +103,12 @@ public sealed partial class ResearchSystem
 
         TryGetClientServer(uid, out _, out var serverComponent, component);
 
-        var names = GetServerNames();
-        var state = new ResearchClientBoundInterfaceState(names.Length, names,
-            GetServerIds(), serverComponent?.Id ?? -1);
+        var names = GetServerNames(uid);
+        var state = new ResearchClientBoundInterfaceState(
+            names.Length,
+            names,
+            GetServerIds(uid),
+            serverComponent?.Id ?? -1);
 
         _uiSystem.SetUiState(uid, ResearchClientUiKey.Key, state);
     }


### PR DESCRIPTION
Делает сервера РНД локальными для каждого грида

<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Так как сервера глобальные, это значит что каждый сможет украсть технологию, если её создавать на другом гриде.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
изменяет исследовательский код для использования общего метода доступа к серверам.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
<!--
:cl:
- add: Добавлено веселье!
- remove: Удалено веселье!
- tweak: Изменено веселье!
- fix: Исправлено веселье!
-->
`GetServerIds`, `GetServerNames`, и `TryGetServerById` в Server.ResearchSystem теперь имеют дополнительный параметр для клиента исследования.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Research clients now automatically register or unregister with research servers based on their anchored state.
  * Server lists and selection are now filtered to only show research servers available on the same grid as the client.

* **Improvements**
  * Enhanced validation to ensure clients can only access research servers they are eligible for.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->